### PR TITLE
Add Support for Docker Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/resources
 test/*.json
+/.project

--- a/README.md
+++ b/README.md
@@ -81,6 +81,37 @@ The CommandBox Docker image support the use of environmental variables for the c
 
 * `$HEALTHCHECK_URI` - Specifies the URI endpoint for container [health checks](https://docs.docker.com/engine/reference/builder/#healthcheck).  By default, this defaults to `http://127.0.0.1:${PORT}/` at 20 second intervals, a timeout of 30 seconds,  with 15 retries before the container is marked as failed.  _Note: Since the interval, timeout, and retry settings cannot be set dynamically, if you need to adjust these, you will need to build from a Dockerfile which provides a new [`HEALTHCHECK` command](https://docs.docker.com/engine/reference/builder/#healthcheck)
 
+Docker Secrets
+==============
+
+[Docker secrets](https://docs.docker.com/engine/swarm/secrets/) can use two storage mechanisms:
+
+* Secret values stored as files on the host (non-swarm mode).
+* `docker secret`-managed key/value pairs (swarm mode).
+
+To use secrets as variables in this image, a placeholder is specified (e.g., `{{DOCKER-SECRET:test_docker_secret}}`) as the variable's value. At run-time, the environment variable's value is replaced with the secret.
+
+Example with a secret using host file storage:
+
+```yml
+version: '3.1'
+
+services:
+
+  sut:
+    environment:
+      - IMAGE_TESTING_IN_PROGRESS=true
+      #- ENV_SECRETS_DEBUG # uncomment to debug the placeholder replacements
+      # this is a placeholder that will be replaced at runtime with the secret value
+      - TEST_DOCKER_SECRET={{DOCKER-SECRET:test_docker_secret}}
+    ...
+    
+secrets:
+  test_docker_secret:
+    # this is the file containing the secret value
+    file: ./build/tests/secrets/test_docker_secret
+```
+
 About CommandBox
 ================
 

--- a/build/run.sh
+++ b/build/run.sh
@@ -2,6 +2,8 @@
 set -e
 cd $APP_DIR
 
+. $BUILD_DIR/util/env-secrets-expand.sh
+
 SECONDS=0
 
 # CFConfig Available Password Keys

--- a/build/tests/myConfigs.json
+++ b/build/tests/myConfigs.json
@@ -1,0 +1,3 @@
+{
+    "adminPassword": "${TEST_DOCKER_SECRET}"
+}

--- a/build/tests/secrets/test_docker_secret
+++ b/build/tests/secrets/test_docker_secret
@@ -1,0 +1,1 @@
+secretvalue

--- a/build/tests/test.cfconfig.env.sh
+++ b/build/tests/test.cfconfig.env.sh
@@ -3,7 +3,7 @@ cd $APP_DIR
 echo "Starting server with cfconfig environment variable set"
 
 runOutput="$( ${BUILD_DIR}/run.sh )"
-printf "${runOutput}"
+printf "${runOutput}\n"
 
 $BUILD_DIR/tests/test.up.sh
 

--- a/build/tests/test.cfconfig.file.sh
+++ b/build/tests/test.cfconfig.file.sh
@@ -13,7 +13,7 @@ echo "Starting server with cfconfig file variable set"
 
 runOutput="$( ${BUILD_DIR}/run.sh )"
 
-printf "${runOutput}"
+printf "${runOutput}\n"
 
 $BUILD_DIR/tests/test.up.sh
 

--- a/build/util/env-secrets-expand.sh
+++ b/build/util/env-secrets-expand.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# credit: https://medium.com/@basi/docker-environment-variables-expanded-from-secrets-8fa70617b3bc
+
+: ${ENV_SECRETS_DIR:=/run/secrets}
+
+env_secret_debug()
+{
+    if [ ! -z "$ENV_SECRETS_DEBUG" ]; then
+        echo -e "\033[1m$@\033[0m"
+    fi
+}
+
+# usage: env_secret_expand VAR
+#    ie: env_secret_expand 'XYZ_DB_PASSWORD'
+# (will check for "$XYZ_DB_PASSWORD" variable value for a placeholder that defines the
+#  name of the docker secret to use instead of the original value. For example:
+# XYZ_DB_PASSWORD={{DOCKER-SECRET:my-db.secret}}
+env_secret_expand() {
+    var="$1"
+    eval val=\$$var
+    if secret_name=$(expr match "$val" "{{DOCKER-SECRET:\([^}]\+\)}}$"); then
+        secret="${ENV_SECRETS_DIR}/${secret_name}"
+        env_secret_debug "Secret file for $var: $secret"
+        if [ -f "$secret" ]; then
+            val=$(cat "${secret}")
+            export "$var"="$val"
+            env_secret_debug "Expanded variable: $var=$val"
+        else
+            export "$var"=""
+            env_secret_debug "Secret file does not exist! $secret"
+        fi
+    fi
+}
+
+env_secrets_expand() {
+    for env_var in $(printenv | cut -f1 -d"=")
+    do
+        env_secret_expand $env_var
+    done
+
+    if [ ! -z "$ENV_SECRETS_DEBUG" ]; then
+        echo -e "\n\033[1mExpanded environment variables\033[0m"
+        printenv
+    fi
+}
+
+env_secrets_expand

--- a/docker-compose.secret-test.yml
+++ b/docker-compose.secret-test.yml
@@ -1,0 +1,30 @@
+version: '3.1'
+
+# This tests the CommandBox Docker Secrets implementation
+# To test:
+# BUILD_IMAGE_DOCKERFILE=Dockerfile BUILD_IMAGE_TAG=ortussolutions/commandbox docker-compose -f docker-compose.secret-test.yml up --build
+# The proof is that the admin (http://localhost:8080/lucee/admin/web.cfm) will have the password secretvalue, which comes from the test_docker_secret Docker secret.
+
+services:
+
+  sut:
+    build:
+      context: .
+      dockerfile: "./${BUILD_IMAGE_DOCKERFILE}"
+    container_name: secret-test
+    environment:
+      #- ENV_SECRETS_DEBUG # uncomment to emit output during secret replacement
+      - SOME_VAR=foo
+      - TEST_DOCKER_SECRET={{DOCKER-SECRET:test_docker_secret}}
+      - CFCONFIG=/build/tests/myConfigs.json
+    ports:
+      - 8080:8080
+    volumes: 
+      - ./test:/app
+      - ./build:/build
+    secrets:
+      - test_docker_secret
+
+secrets:
+  test_docker_secret:
+    file: ./build/tests/secrets/test_docker_secret


### PR DESCRIPTION
This is a work in progress. I'm trying to get the image to support Docker secrets.

[Here's an explanation](https://github.com/jamiejackson/docker-commandbox/blob/docker-secrets/TEMP_README.md) of where I am. I'm having trouble getting automated tests going with this. However, it's possible that the image itself would actually work properly if it were run directly (I haven't tried that yet.)

1. Could you comment on the idea and whether there's an interest in this?
2. Suggestions as to getting the automated tests running? (Assuming they're even relevant, since the test script does things kinda differently than a real container being started fresh.)

