### PR TITLE
fix secret variable resolution

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -5,7 +5,7 @@ cd $APP_DIR
 SECONDS=0
 
 # Handle secret expansion before any other environmental variables are processed
-$BUILD_DIR/util/env-secrets-expand.sh
+. $BUILD_DIR/util/env-secrets-expand.sh
 
 # CFConfig Available Password Keys
 CFCONFIG_PASSWORD_KEYS=( "adminPassword" "adminPasswordDefault" "hspw" "pw" "defaultHspw" "defaultPw" "ACF11Password" )


### PR DESCRIPTION
The rework in https://github.com/Ortus-Solutions/docker-commandbox/commit/c8629321f215393d7accd7474f7c8f244c390453#diff-37d2d95e893acec564296683469a025c broke the secrets environment variable replacements. The `env-secrets-expand.sh` must be sourced.

We need something more like end-to-end tests for this, as the current tests don't represent reality very well.

Here's an end-to-end test to prove this pull request:

Grab my [original compose test file](https://raw.githubusercontent.com/Ortus-Solutions/docker-commandbox/25e16f3db2a10d54bd8b50bd010b7f278c9f10d1/build/util/env-secrets-expand.sh) and place it.

Run it with:

```sh
 BUILD_IMAGE_DOCKERFILE=Dockerfile BUILD_IMAGE_TAG=ortussolutions/commandbox \
  docker-compose -f docker-compose.secret-test.yml up --build
```

If you can login to http://localhost:8080/lucee/admin/web.cfm with `secretvalue` ([the value of the secret](https://github.com/Ortus-Solutions/docker-commandbox/blob/6d0e6fd83137d433dd89bdd15b7e7656c400a256/build/tests/secrets/test_docker_secret)), then secrets support is working correctly; if not, it is broken.



