### PR TITLE
Ver and script updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ services:
 
 script:
   # update our version numbers before building
-  - find ./builds/base -type f -exec sed -i '' -e "s/@version@/2\.6\.0/g" {} \;
+  - find ./builds/base -type f -exec sed -i '' -e "s/@version@/${IMAGE_VERSION}/g" {} \;
   - docker build --no-cache --build-arg COMMANDBOX_VERSION=$COMMANDBOX_VERSION -t commandbox-base -f ./$BASE_BUILD_FILE $TRAVIS_BUILD_DIR/
   - docker-compose -f docker-compose.test.yml up --build --exit-code-from sut
   - docker-compose -f docker-compose.secret-test.yml up --build --exit-code-from sut

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 env:
   global:
     - IMAGE_VERSION=2.6.0
-    - COMMANDBOX_VERSION=4.5.0
+    - COMMANDBOX_VERSION=4.6.0
   matrix:
     # Debian Builds
     - BUILD_IMAGE_DOCKERFILE=builds/Base.Dockerfile BASE_BUILD_FILE=builds/base/Dockerfile BUILD_IMAGE_TAG=ortussolutions/commandbox

--- a/build/util/install-cfconfig.sh
+++ b/build/util/install-cfconfig.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # Install the CFConfig Module
 box install commandbox-cfconfig --production
 $BUILD_DIR/util/optimize.sh

--- a/build/util/install-commandbox.sh
+++ b/build/util/install-commandbox.sh
@@ -11,7 +11,7 @@ set -ex
 # Installs the latest CommandBox Binary
 mkdir -p /tmp
 curl -k  -o /tmp/box.zip -location "https://downloads.ortussolutions.com/ortussolutions/commandbox/${COMMANDBOX_VERSION}/commandbox-bin-${COMMANDBOX_VERSION}.zip"
-unzip /tmp/box.zip -d ${BIN_DIR} && chmod +x ${BIN_DIR}/box
+unzip /tmp/box.zip -d ${BIN_DIR} && chmod 755 ${BIN_DIR}/box
 echo "$(box version) successfully installed"
 
 # Cleanup CommandBox modules which would not be necessary in a Container environment

--- a/build/util/install-commandbox.sh
+++ b/build/util/install-commandbox.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ -z "$COMMANDBOX_VERSION" ]; then
+  echo "CommandBox Version not supplied via variable COMMANDBOX_VERSION"
+  exit 1
+fi
+
+# Make sure errors (like curl failing, or unzip failing, or anything failing) fails the build
+set -ex
+
 # Installs the latest CommandBox Binary
 mkdir -p /tmp
 curl -k  -o /tmp/box.zip -location "https://downloads.ortussolutions.com/ortussolutions/commandbox/${COMMANDBOX_VERSION}/commandbox-bin-${COMMANDBOX_VERSION}.zip"

--- a/build/util/install-dotenv.sh
+++ b/build/util/install-dotenv.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # Install the CommandBox-DotEnv module
 box install commandbox-dotenv --production
 $BUILD_DIR/util/optimize.sh

--- a/update_travis.sh
+++ b/update_travis.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+LOC=$(curl -fsSL -I https://www.ortussolutions.com/parent/download/commandbox/type/bin |grep -i location: |tail -n1 |sed -n 's,^location: ,,ip'|sed -e 's,\r,,g;')
+VER=$(echo $LOC |sed -n 's,^.*/ortussolutions/commandbox/\([^/]*\)/commandbox-bin.*,\1,p')
+
+perl -pi -e "s|(-\s*COMMANDBOX_VERSION)=\S+|\$1=${VER}|" .travis.yml
+


### PR DESCRIPTION
Updates to the build environment.

First build I hadn't set COMMANDBOX_VERSION and it didn't..fail.. It just said " installed successfully.", and showed unzip failures, and errors running installs etc etc etc

Fixed that, my image runs non-root so 755 is needed for the box binary.  Added a helper to derive the commandbox version from the ortus website and update the .travis.yml file, and use IMAGE_VERSION variable instead of explicitly setting it (since \. isn't needed in replacement strings anyway)

