### PR TITLE
Always use --verbose flag when starting server

### DIFF
--- a/build/util/start-server.sh
+++ b/build/util/start-server.sh
@@ -77,7 +77,8 @@ if [[ $CFENGINE ]]; then
         debug=${DEBUG_FLAG} \
         dryRun=${DRY_RUN_FLAG} \
         console=${DRY_RUN_FLAG} \
-        startScript=${SCRIPT_TYPE}
+        startScript=${SCRIPT_TYPE} \
+        verbose=true
 else
     box server start \
         serverHomeDirectory=${SERVER_HOME_DIRECTORY} \
@@ -92,7 +93,8 @@ else
         debug=${DEBUG_FLAG} \
         dryRun=${DRY_RUN_FLAG} \
         console=${DRY_RUN_FLAG} \
-        startScript=${SCRIPT_TYPE}
+        startScript=${SCRIPT_TYPE} \
+        verbose=true
 fi
 
 # If not testing then the script was generated and we run it directly, bypassing the CommandBox wrapper


### PR DESCRIPTION
This will ensure useful debugging information is in the container logs from the server start, but will not affect the operation of the server in the same manner the debug flag does once the server is up.